### PR TITLE
use node-gyp and libnotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This is a follow up to [How to roll out your own Javascript API with V8](http://
 
 ## Install ##
 
-Dependencies(Ubuntu 11.04):
+Dependencies(Debian, Ubuntu):
 
-    sudo apt-get install libnotifymm-dev
+    sudo apt-get install libnotify-dev
 
 Using npm:
 
@@ -15,15 +15,23 @@ Using npm:
     
 Manually:
 
-    node-waf configure && node-waf build
+    node-gyp configure && node-gyp build
 
 ## Usage ##
 
-    var notify = require("notify"); // or "../build/default/gtknotify.node" if you build manually
+    var notify = require("notify"); // or "../build/Release/gtknotify.node" if you build manually
     var notification = new notify.notification();
     notification.title = "Notification title";
     notification.icon = "emblem-default"; // see /usr/share/icons/gnome/16x16
-    notification.send("Notification message");
+    notification.send("Notification message"); // using libnotify's default timeout
+
+To send notification with a timeout:
+
+    notification.send("Notification message", 3000); // 3 sec timeout
+    // or
+    notification.send("Notification message", 0); // lasts forever
+    notification.close(); // closes it
+
 
 ## References ##
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,14 +2,13 @@
   "targets": [
     {
       "target_name": "gtknotify",
-      "include_dirs": "/root/src/../api",
       "sources": [ "src/node_gtknotify.cpp" ],
-     },
-     'link_settings': {
-          'libraries': [
-              '-lgtkmm-2.4',
-              '-llibnotifymm-1.0'
-          ]
-      }
-    ]
+      "include_dirs": [
+        "<!@(pkg-config libnotify --cflags-only-I | sed s/-I//g)"
+      ],
+      "libraries": [
+        "<!@(pkg-config libnotify --libs)"
+      ]
+    }
+  ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,15 @@
+{
+  "targets": [
+    {
+      "target_name": "gtknotify",
+      "include_dirs": "/root/src/../api",
+      "sources": [ "src/node_gtknotify.cpp" ],
+     },
+     'link_settings': {
+          'libraries': [
+              '-lgtkmm-2.4',
+              '-llibnotifymm-1.0'
+          ]
+      }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
       , "url" : "https://github.com/olalonde/node-notify.git"
     }
   , "scripts" : {
-      "preinstall" : "node-waf configure && node-waf build"
+      "preinstall" : "node-gyp configure && node-gyp build"
       , "preuninstall" : "rm -rf build/*"
     }
-  , "main" : "build/default/gtknotify.node"
+  , "main" : "build/Release/gtknotify.node"
 }


### PR DESCRIPTION
Hi,
Combined with @jutaz's patch, this PR setup the node-gyp build and use libnotify instead of libnotifymm (as libnotify is more commonly installed on systems than the c++ bindings).
